### PR TITLE
Fixing duplicate references

### DIFF
--- a/docs/multiversion_config/conf.py
+++ b/docs/multiversion_config/conf.py
@@ -42,13 +42,10 @@
 import os
 import sys
 import re
-from datetime import datetime
 from pathlib import Path
 from git import Repo
 
 sys.path.insert(0, os.path.relpath("../"))
-
-from perceval import PMetadata
 
 
 def version_highter_then(v1, v2):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -92,6 +92,7 @@ extensions = [
 suppress_warnings = ['autosectionlabel.*']
 bibtex_bibfiles = ["references.bib"]
 bibtex_reference_style = "author_year"
+# TODO: this sets the output style of references. I wanted to check if any other rendered better than the current.
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -52,29 +52,11 @@
   publisher={Nature Publishing Group}
 }
 
-@article{knill_note_2002,
-	title = {A {Note} on {Linear} {Optics} {Gates} by {Post}-{Selection}},
-	volume = {66},
-	issn = {1050-2947, 1094-1622},
-	url = {http://arxiv.org/abs/quant-ph/0110144},
-	doi = {10.1103/PhysRevA.66.052306},
-	abstract = {Recently it was realized that linear optics and photo-detectors with feedback can be used for theoretically efficient quantum information processing. The first of three steps toward efficient linear optics quantum computation (eLOQC) was to design a simple non-deterministic gate, which upon post-selection based on a measurement result implements a non-linear phase shift on one mode. Here a computational strategy is given for finding non-deterministic gates for bosonic qubits with helper photons. A more efficient conditional sign flip gate is obtained.},
-	number = {5},
-	urldate = {2022-03-04},
-	journal = {Physical Review A},
-	author = {Knill, E.},
-	month = nov,
-	year = {2002},
-	note = {arXiv: quant-ph/0110144},
-	keywords = {Quantum Physics},
-	pages = {052306},
-	file = {arXiv.org Snapshot:/Users/shaman/Zotero/storage/YXJK5MXR/0110144.html:text/html;arXiv Fulltext PDF:/Users/shaman/Zotero/storage/LGFXF8BK/Knill - 2002 - A Note on Linear Optics Gates by Post-Selection.pdf:application/pdf},
-}
-
 @article{knill_quantum_2002,
 	title = {Quantum gates using linear optics and postselection},
 	volume = {66},
 	url = {https://link.aps.org/doi/10.1103/PhysRevA.66.052306},
+	eprint = {http://arxiv.org/abs/quant-ph/0110144},
 	doi = {10.1103/PhysRevA.66.052306},
 	abstract = {Recently it was realized that linear optics and photodetectors with feedback can be used for theoretically efficient quantum information processing. The first of three steps toward efficient linear optics quantum computation is to design a simple postselected gate that implements a nonlinear phase shift on one mode. Here a computational strategy is given for finding postselected gates for bosonic qubits with helper photons. A more efficient conditional sign flip gate is obtained. What is the maximum efficiency for such gates? This question is posed and it is shown that the probability of success cannot be 1.},
 	number = {5},
@@ -369,40 +351,6 @@ Publisher: Nature Publishing Group},
 	file = {APS Snapshot:/Users/shaman/Zotero/storage/GF3L48VV/PhysRevLett.59.html:text/html},
 }
 
-@article{hong_measurement_1987-1,
-	title = {Measurement of subpicosecond time intervals between two photons by interference},
-	volume = {59},
-	url = {https://link.aps.org/doi/10.1103/PhysRevLett.59.2044},
-	doi = {10.1103/PhysRevLett.59.2044},
-	abstract = {A fourth-order interference technique has been used to measure the time intervals between two photons, and by implication the length of the photon wave packet, produced in the process of parametric down-conversion. The width of the time-interval distribution, which is largely determined by an interference filter, is found to be about 100 fs, with an accuracy that could, in principle, be less than 1 fs.},
-	number = {18},
-	urldate = {2022-03-18},
-	journal = {Physical Review Letters},
-	author = {Hong, C. K. and Ou, Z. Y. and Mandel, L.},
-	month = nov,
-	year = {1987},
-	note = {Publisher: American Physical Society},
-	pages = {2044--2046},
-	file = {APS Snapshot:/Users/shaman/Zotero/storage/VA5CKHV5/PhysRevLett.59.html:text/html},
-}
-
-@article{hong_measurement_1987-2,
-	title = {Measurement of subpicosecond time intervals between two photons by interference},
-	volume = {59},
-	issn = {0031-9007},
-	url = {https://link.aps.org/doi/10.1103/PhysRevLett.59.2044},
-	doi = {10.1103/PhysRevLett.59.2044},
-	language = {en},
-	number = {18},
-	urldate = {2022-03-18},
-	journal = {Physical Review Letters},
-	author = {Hong, C. K. and Ou, Z. Y. and Mandel, L.},
-	month = nov,
-	year = {1987},
-	pages = {2044--2046},
-	file = {Hong et al. - 1987 - Measurement of subpicosecond time intervals betwee.pdf:/Users/shaman/Zotero/storage/K9MB6ZZD/Hong et al. - 1987 - Measurement of subpicosecond time intervals betwee.pdf:application/pdf},
-}
-
 @inproceedings{gan_fock_2021,
 	title = {Fock {State}-enhanced {Expressivity} of {Quantum} {Machine} {Learning} {Models}},
 	copyright = {\&\#169; 2021 The Author(s)},
@@ -507,30 +455,12 @@ Publisher: Nature Publishing Group},
   publisher={Verein zur F{\"o}rderung des Open Access Publizierens in den Quantenwissenschaften}
 }
 
-@article{valiant1979complexity,
-  title={The complexity of computing the permanent},
-  author={Valiant, Leslie G},
-  journal={Theoretical computer science},
-  volume={8},
-  number={2},
-  pages={189--201},
-  year={1979},
-  publisher={Elsevier}
-}
-
 @book{brualdi1991combinatorial,
   title={Combinatorial matrix theory},
   author={Brualdi, Richard A and Ryser, Herbert John and others},
   volume={39},
   year={1991},
   publisher={Springer}
-}
-
-@article{MM22,
-  title={Assessing the quality of near-term photonic quantum devices},
-  author={Mezher, Rawad and Mansfield, Shane},
-  journal={arXiv preprint arXiv:2202.04735},
-  year={2022}
 }
 
 @article{Haar17,
@@ -542,29 +472,6 @@ Publisher: Nature Publishing Group},
   pages={033007},
   year={2017},
   publisher={IOP Publishing}
-}
-
-
-@article{Clements16,
-  title={Optimal design for universal multiport interferometers},
-  author={Clements, William R and Humphreys, Peter C and Metcalf, Benjamin J and Kolthammer, W Steven and Walmsley, Ian A},
-  journal={Optica},
-  volume={3},
-  number={12},
-  pages={1460--1465},
-  year={2016},
-  publisher={Optical Society of America}
-}
-
-@article{Reck94,
-  title={Experimental realization of any discrete unitary operator},
-  author={Reck, Michael and Zeilinger, Anton and Bernstein, Herbert J and Bertani, Philip},
-  journal={Physical review letters},
-  volume={73},
-  number={1},
-  pages={58},
-  year={1994},
-  publisher={APS}
 }
 
 @article{KK14,
@@ -688,25 +595,6 @@ Publisher: Nature Publishing Group},
 	year = {2009},
 	note = {Publisher: American Association for the Advancement of Science},
 	pages = {1221--1221}
-}
-
-@inproceedings{aaronson_computational_2011-1,
-	address = {New York, NY, USA},
-	series = {{STOC} '11},
-	title = {The computational complexity of linear optics},
-	isbn = {978-1-4503-0691-1},
-	url = {https://doi.org/10.1145/1993636.1993682},
-	doi = {10.1145/1993636.1993682},
-	abstract = {We give new evidence that quantum computers -- moreover, rudimentary quantum computers built entirely out of linear-optical elements -- cannot be efficiently simulated by classical computers. In particular, we define a model of computation in which identical photons are generated, sent through a linear-optical network, then nonadaptively measured to count the number of photons in each mode. This model is not known or believed to be universal for quantum computation, and indeed, we discuss the prospects for realizing the model using current technology. On the other hand, we prove that the model is able to solve sampling problems and search problems that are classically intractable under plausible assumptions. Our first result says that, if there exists a polynomial-time classical algorithm that samples from the same probability distribution as a linear-optical network, then P\#P=BPPNP, and hence the polynomial hierarchy collapses to the third level. Unfortunately, this result assumes an extremely accurate simulation. Our main result suggests that even an approximate or noisy classical simulation would already imply a collapse of the polynomial hierarchy. For this, we need two unproven conjectures: the Permanent-of-Gaussians Conjecture, which says that it is \#P-hard to approximate the permanent of a matrix A of independent N(0,1) Gaussian entries, with high probability over A; and the Permanent Anti-Concentration Conjecture, which says that {\textbar}Per(A){\textbar}{\textgreater}=√(n!)poly(n) with high probability over A. We present evidence for these conjectures, both of which seem interesting even apart from our application. This paper does not assume knowledge of quantum optics. Indeed, part of its goal is to develop the beautiful theory of noninteracting bosons underlying our model, and its connection to the permanent function, in a self-contained way accessible to theoretical computer scientists.},
-	urldate = {2022-03-22},
-	booktitle = {Proceedings of the forty-third annual {ACM} symposium on {Theory} of computing},
-	publisher = {Association for Computing Machinery},
-	author = {Aaronson, Scott and Arkhipov, Alex},
-	month = jun,
-	year = {2011},
-	keywords = {\#p, BGP, bosons, linear optics, permanent, polynomial hierarchy, random self-reducibility, sampling},
-	pages = {333--342},
-	file = {Full Text PDF:/Users/shaman/Zotero/storage/KK9GAHK9/Aaronson and Arkhipov - 2011 - The computational complexity of linear optics.pdf:application/pdf},
 }
 
 @article{hilaire_error-correcting_2021,
@@ -1113,20 +1001,6 @@ Noisy Intermediate-Scale Quantum (NISQ) technology will be available in the near
   publisher = {arXiv},
   year = {2011},
   copyright = {arXiv.org perpetual, non-exclusive license}
-}
-
-@article{J.W.Pan_BS_2020,
-author = {Han-Sen Zhong  and Hui Wang  and Yu-Hao Deng  and Ming-Cheng Chen  and Li-Chao Peng  and Yi-Han Luo  and Jian Qin  and Dian Wu  and Xing Ding  and Yi Hu  and Peng Hu  and Xiao-Yan Yang  and Wei-Jun Zhang  and Hao Li  and Yuxuan Li  and Xiao Jiang  and Lin Gan  and Guangwen Yang  and Lixing You  and Zhen Wang  and Li Li  and Nai-Le Liu  and Chao-Yang Lu  and Jian-Wei Pan },
-title = {Quantum computational advantage using photons},
-journal = {Science},
-volume = {370},
-number = {6523},
-pages = {1460-1463},
-year = {2020},
-doi = {10.1126/science.abe8770},
-URL = {https://www.science.org/doi/abs/10.1126/science.abe8770},
-eprint = {https://www.science.org/doi/pdf/10.1126/science.abe8770},
-abstract = {Quantum computational advantage or supremacy is a long-anticipated milestone toward practical quantum computers. Recent work claimed to have reached this point, but subsequent work managed to speed up the classical simulation and pointed toward a sample size–dependent loophole. Quantum computational advantage, rather than being a one-shot experimental proof, will be the result of a long-term competition between quantum devices and classical simulation. Zhong et al. sent 50 indistinguishable single-mode squeezed states into a 100-mode ultralow-loss interferometer and sampled the output using 100 high-efficiency single-photon detectors. By obtaining up to 76-photon coincidence, yielding a state space dimension of about 1030, they measured a sampling rate that is about 1014-fold faster than using state-of-the-art classical simulation strategies and supercomputers. Science, this issue p. 1460 Quantum computational advantage is demonstrated using boson sampling with photons. Quantum computers promise to perform certain tasks that are believed to be intractable to classical computers. Boson sampling is such a task and is considered a strong candidate to demonstrate the quantum computational advantage. We performed Gaussian boson sampling by sending 50 indistinguishable single-mode squeezed states into a 100-mode ultralow-loss interferometer with full connectivity and random matrix—the whole optical setup is phase-locked—and sampling the output using 100 high-efficiency single-photon detectors. The obtained samples were validated against plausible hypotheses exploiting thermal states, distinguishable photons, and uniform distribution. The photonic quantum computer, Jiuzhang, generates up to 76 output photon clicks, which yields an output state-space dimension of 1030 and a sampling rate that is faster than using the state-of-the-art simulation strategy and supercomputers by a factor of ~1014.}
 }
 
 @article{glynn2010permanent,


### PR DESCRIPTION
The following changes have been made -

- Removed unused imports from conf.py in multiversion_config
- Added a TODO in source/conf.py (it is about bibliographystyle). I was unable to build docs so I could not check if any other looked better.
- I removed instances of duplicate reference entries in reference.bib script. Pycharm File in Finder did not find them. However, I still wanted to check there are no broken citations in notebooks/examples. Unfortunately without the build I could not do it.